### PR TITLE
fix(webpack): startTime in readonly in stats

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,11 @@ module.exports = class TimeFixPlugin {
     // Reset time
     compiler.hooks.done.tap('time-fix-plugin', stats => {
       if (watching && !fixed) {
-        stats.startTime -= this.watchOffset
+        if (stats.compilation.startTime) {
+          stats.compilation.startTime -= this.watchOffset
+        } else {
+          stats.startTime -= this.watchOffset
+        }
         fixed = true
       }
     })

--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ module.exports = class TimeFixPlugin {
     // Reset time
     compiler.hooks.done.tap('time-fix-plugin', stats => {
       if (watching && !fixed) {
+        // webpack 5: #3
         if (stats.compilation.startTime) {
           stats.compilation.startTime -= this.watchOffset
         } else {


### PR DESCRIPTION
`startTime` has been moved to  from Stats to Compilation since https://github.com/webpack/webpack/commit/8497cd34c61819dfcfe4bf00c686574f1af72b72 , this pr is fixing this for webpack 5